### PR TITLE
feat: create Terraform charm module to comply with CC006 (`latest-stable/edge`)

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,16 @@
+terraform.tfvars
+.terraform/
+*.pem
+*.asc
+*.tfstate
+*.tfstate.*
+*.tfvars.json
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+# Normally other charm modules do not include the lock file it seems
+.terraform.lock.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,61 @@
+# Landscape Server charm Terraform module
+
+This folder contains a base [Terraform][Terraform] module for the landscape-server charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm
+deployment onto any machine cloud environment managed by [Juju][Juju].
+
+The base module is not intended to be deployed in separation (it is possible though), but should
+rather serve as a building block for higher level modules.
+
+## Module structure
+
+- **main.tf** - Defines the Juju application to be deployed.
+- **variables.tf** - Allows customization of the deployment. Except for exposing the deployment
+  options (Juju model name, channel or application name) also models the charm configuration.
+- **output.tf** - Responsible for integrating the module with other Terraform modules, primarily
+  by defining potential integration endpoints (charm integrations), but also by exposing
+  the application name.
+- **versions.tf** - Defines the Terraform provider version.
+
+## Using the landscape-server base module in higher level modules
+
+If you want to use `landscape-server` base module as part of your Terraform module, import it
+like shown below:
+
+```hcl
+data "juju_model" "my_model" {
+  name = var.model
+}
+
+module "landscape_server" {
+  source = "git::https://github.com/canonical/landscape-charm//terraform"
+  
+  model = juju_model.my_model.name
+  (Customize configuration variables here if needed)
+}
+```
+
+Create integrations, for instance:
+
+```hcl
+resource "juju_integration" "landscape_server_haproxy" {
+  model = juju_model.my_model.name
+  application {
+    name     = module.landscape_server.app_name
+    endpoint = module.landscape_server.requires.website
+  }
+
+  application {
+    name     = module.haproxy.app_name
+    endpoint = module.haproxy.provides.website
+  }
+}
+```
+
+The complete list of available integrations can be found [on Charmhub][integrations].
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[Juju]: https://juju.is
+[integrations]: https://charmhub.io/landscape-server/integrations?channel=latest-stable/edge

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,20 @@
+# © 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "landscape_server" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "landscape-server"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+  resources   = var.resources
+  trust       = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,33 @@
+# © 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.landscape_server.name
+}
+
+output "requires" {
+  value = {
+    application_dashboard = "application-dashboard"
+    db                    = "db"
+    inbound_amqp          = "inbound-amqp"
+    outbound_amqp         = "outbound-amqp"
+  }
+}
+
+output "provides" {
+  value = {
+    cos_agent            = "cos-agent"
+    data                 = "data"
+    hosted               = "hosted"
+    nrpe_external_master = "nrpe-external-master"
+    website              = "website"
+  }
+}
+
+output "endpoints" {
+  value = {
+    mimir_cluster = "mimir-cluster"
+    metrics       = "prometheus-metrics"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,56 @@
+# © 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "landscape-server"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "latest-stable/edge"
+}
+
+variable "config" {
+  description = "Application config. Details about available options can be found at https://charmhub.io/landscape-server/configurations?channel=latest-stable/edge."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+  default     = ""
+}
+
+variable "resources" {
+  description = "Resources to use with the application. Details about available options can be found at https://charmhub.io/landscape-server/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,11 @@
+# © 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.11.0"
+    }
+  }
+}


### PR DESCRIPTION
Spec: https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit?tab=t.0#heading=h.gaucm6281bb6

Based heavily on: https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/terraform (which complies with the spec)

## Manual testing

```sh
sudo snap install terraform --classic
sudo snap install juju --classic
```

```sh
terraform init
```

Create a Juju model

```sh
# If no cloud bootstrapped
# juju bootstrap lxd landscape-controller
juju add-model landscape
```

```sh
terraform plan
```

Apply the plan to deploy the module:

```sh
terraform apply -var model=landscape
```