### PR TITLE
feat: write to the new sections of service.conf; add migration action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -9,7 +9,9 @@ upgrade:
   description: |
     Upgrade software on the Landscape Server unit. This will update
     APT package indices and upgrade the landscape-server package. Unit must
-    already be paused using the 'pause' action.
+    already be paused using the 'pause' action. If upgrading from a version
+    of Landscape Server earlier than 25.10, it is recommended to run the
+    migrate-service-conf action prior to upgrading.
 migrate-schema:
   description: |
     Upgrade the Landscape database schemas on the related databases.
@@ -18,3 +20,10 @@ hash-id-databases:
   description: |
     Regenerate the package hash to id mapping files that are used to
     speed up client package reporting.
+migrate-service-conf:
+  description: |
+    Rewrite the service.conf file on each unit, replacing deprecated
+    fields with the new ones. This action is idempotent and only needs
+    to be run if Landscape Server 25.10 or later is installed, but the
+    service.conf file was configured by an earlier version of Landscape
+    Server.

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,7 +61,10 @@ from settings_files import (
     DEFAULT_POSTGRES_PORT,
     generate_secret_token,
     merge_service_conf,
+    migrate_service_conf,
     prepend_default_settings,
+    read_service_conf,
+    SERVICE_CONF,
     update_db_conf,
     update_default_settings,
     update_service_conf,
@@ -436,6 +439,9 @@ class LandscapeServerCharm(CharmBase):
         self.framework.observe(
             self.on.hash_id_databases_action, self._hash_id_databases
         )
+        self.framework.observe(
+            self.on.migrate_service_conf_action, self._migrate_service_conf
+        )
 
         # State
         self._stored.set_default(
@@ -488,13 +494,14 @@ class LandscapeServerCharm(CharmBase):
 
         # Update additional configuration
         deployment_mode = self.model.config.get("deployment_mode")
-        update_service_conf({"global": {"deployment-mode": deployment_mode}})
+        update_service_conf({"system": {"deployment_mode": deployment_mode}})
 
         configure_for_deployment_mode(deployment_mode)
 
         additional_config = self.model.config.get("additional_service_config")
         if additional_config:
             merge_service_conf(additional_config)
+            migrate_service_conf()
 
         # Write the config-provided SSL certificate, if it exists.
         config_ssl_cert = self.model.config["ssl_cert"]
@@ -538,13 +545,13 @@ class LandscapeServerCharm(CharmBase):
 
         service_conf_updates = {
             service: {"workers": str(workers)}
-            for service in ("landscape", "api", "message-server", "pingserver")
+            for service in ("appserver", "api", "message_server", "pingserver")
         }
 
         if root_url:
-            service_conf_updates["global"] = {"root-url": root_url}
-            service_conf_updates["api"]["root-url"] = root_url
-            service_conf_updates["package-upload"]["root-url"] = root_url
+            service_conf_updates["system"] = {"root_url": root_url}
+            service_conf_updates["api"]["root_url"] = root_url
+            service_conf_updates["package_upload"]["root_url"] = root_url
 
         update_service_conf(service_conf_updates)
 
@@ -603,7 +610,7 @@ class LandscapeServerCharm(CharmBase):
 
     def _write_secret_token(self, secret_token):
         logger.info("Writing secret token")
-        update_service_conf({"landscape": {"secret-token": secret_token}})
+        update_service_conf({"appserver": {"secret_token": secret_token}})
 
     def _on_install(self, event: InstallEvent) -> None:
         """Handle the install event."""
@@ -966,9 +973,9 @@ class LandscapeServerCharm(CharmBase):
             self._stored.default_root_url = url
             update_service_conf(
                 {
-                    "global": {"root-url": url},
-                    "api": {"root-url": url},
-                    "package-upload": {"root-url": url},
+                    "system": {"root_url": url},
+                    "api": {"root_url": url},
+                    "package_upload": {"root_url": url},
                 }
             )
 
@@ -1163,7 +1170,7 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
 
             update_service_conf(
                 {
-                    "package-search": {
+                    "package_search": {
                         "host": "localhost",
                     },
                 }
@@ -1186,7 +1193,7 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             if leader_ip:
                 update_service_conf(
                     {
-                        "package-search": {
+                        "package_search": {
                             "host": leader_ip,
                         },
                     }
@@ -1245,7 +1252,7 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             if leader_ip_value:
                 update_service_conf(
                     {
-                        "package-search": {
+                        "package_search": {
                             "host": leader_ip_value,
                         },
                     }
@@ -1294,11 +1301,11 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
         if none_count == 0:
             update_service_conf(
                 {
-                    "landscape": {
-                        "oidc-issuer": oidc_issuer,
-                        "oidc-client-id": oidc_client_id,
-                        "oidc-client-secret": oidc_client_secret,
-                        "oidc-logout-url": oidc_logout_url,
+                    "appserver": {
+                        "oidc_issuer": oidc_issuer,
+                        "oidc_client_id": oidc_client_id,
+                        "oidc_client_secret": oidc_client_secret,
+                        "oidc_logout_url": oidc_logout_url,
                     },
                 }
             )
@@ -1306,10 +1313,10 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
             # Only the logout url is optional.
             update_service_conf(
                 {
-                    "landscape": {
-                        "oidc-issuer": oidc_issuer,
-                        "oidc-client-id": oidc_client_id,
-                        "oidc-client-secret": oidc_client_secret,
+                    "appserver": {
+                        "oidc_issuer": oidc_issuer,
+                        "oidc_client_id": oidc_client_id,
+                        "oidc_client_secret": oidc_client_secret,
                     },
                 }
             )
@@ -1331,9 +1338,9 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
         if openid_provider_url and openid_logout_url:
             update_service_conf(
                 {
-                    "landscape": {
-                        "openid-provider-url": openid_provider_url,
-                        "openid-logout-url": openid_logout_url,
+                    "appserver": {
+                        "openid_provider_url": openid_provider_url,
+                        "openid_logout_url": openid_logout_url,
                     },
                 }
             )
@@ -1546,6 +1553,30 @@ command[check_{service}]=/usr/local/lib/nagios/plugins/check_systemd.py {service
         except CalledProcessError as e:
             logger.error("Hashing ID databases failed with error code %s", e.returncode)
             event.fail(f"Hashing ID databases failed with error code {e.returncode}")
+        finally:
+            self.unit.status = prev_status
+
+    def _migrate_service_conf(self, event: ActionEvent) -> None:
+        prev_status = self.unit.status
+        self.unit.status = MaintenanceStatus("Migrating service.conf file...")
+        event.log("Migrating service.conf")
+
+        try:
+            prev_config = read_service_conf()
+            migrate_service_conf()
+        except Exception as e:
+            with open(SERVICE_CONF, "w") as conf_fp:
+                prev_config.write(conf_fp)
+            import traceback
+
+            logger.error("Error migrating service.conf: %s", e)
+            logger.error("Error migrating service.conf: %s", type(e))
+            logger.error("Error migrating service.conf: %s", e.args)
+            logger.error(
+                "Error migrating service.conf: %s", traceback.print_tb(e.__traceback__)
+            )
+            logger.warning("Reverting changes to service.conf")
+            event.fail(f"Error migrating service.conf: {e}")
         finally:
             self.unit.status = prev_status
 

--- a/src/settings_files.py
+++ b/src/settings_files.py
@@ -8,6 +8,7 @@ filesystem.
 from base64 import b64decode, binascii
 from collections import defaultdict
 from configparser import ConfigParser
+from dataclasses import dataclass
 import os
 import secrets
 from string import ascii_letters, digits
@@ -210,3 +211,221 @@ def update_db_conf(
         to_update["schema"]["store_user"] = user
     if to_update:
         update_service_conf(to_update)
+
+
+# The helpers below are essentially copied from the
+# Landscape Server code. They are needed to migrate the service.conf
+# file to migrate sections and options that are deprecated in Landscape
+# Server 25.10.
+# In Landscape Server 26.04, the deprecated portions of service.conf
+# will no longer be supported, and the migration helpers below will
+# no longer be needed.
+@dataclass
+class DeprecatedValue:
+    new_key: str
+    new_section: str | None = None
+
+
+DEPRECATED_SERVICE_OPTIONS = {
+    "base-port": DeprecatedValue(new_key="base_port"),
+    "enable-metrics": DeprecatedValue(new_key="enable_metrics"),
+    "gpg-home-path": DeprecatedValue(new_key="gpg_home_path"),
+    "gpg-passphrase-path": DeprecatedValue(new_key="gpg_passphrase_path"),
+    "mailer-path": DeprecatedValue(new_key="mailer_path"),
+    "oops-key": DeprecatedValue(new_key="oops_key"),
+    "soft-timeout": DeprecatedValue(new_key="soft_timeout"),
+}
+
+
+DEPRECATED_SECTIONS = {
+    "async-frontend": "async_frontend",
+    "fake-openid": "fake_openid",
+    "global": "system",
+    "job-handler": "job_handler",
+    "hostagent-message-consumer": "hostagent_consumer",
+    "hostagent-message-server": "hostagent_server",
+    "landscape": "appserver",
+    "load-shaper": "load_shaper",
+    "message-server": "message_server",
+    "package-search": "package_search",
+    "package-upload": "package_upload",
+    "ubuntu-installer-attach-message-server": "ubuntu_installer_attach",
+}
+
+
+DELETED_SECTIONS = {"pppa-proxy"}
+
+
+DEPRECATED_OPTIONS = {
+    "api": {
+        "cookie-encryption-key": DeprecatedValue(new_key="cookie_encryption_key"),
+        "cors-allow-all": DeprecatedValue(new_key="cors_allow_all"),
+        "root-url": DeprecatedValue(new_key="root_url"),
+        "snap-store-api-url": DeprecatedValue(new_key="snap_store_api_url"),
+    }
+    | DEPRECATED_SERVICE_OPTIONS,
+    "appserver": {
+        "blob-storage-root": DeprecatedValue(new_key="blob_storage_root"),
+        "display-consent-banner-at-each-login": DeprecatedValue(
+            new_key="display_consent_banner_at_each_login"
+        ),
+        "enable-password-authentication": DeprecatedValue(
+            new_key="enable_password_authentication", new_section="system"
+        ),
+        "enable-saas-metrics": DeprecatedValue(
+            new_key="enable_saas_metrics", new_section="system"
+        ),
+        "enable-subdomain-accounts": DeprecatedValue(
+            new_key="enable_subdomain_accounts", new_section="system"
+        ),
+        "enable-tag-script-execution": DeprecatedValue(
+            new_key="enable_tag_script_execution", new_section="system"
+        ),
+        "juju-homes-path": DeprecatedValue(new_key="juju_homes_path"),
+        "known-proxies": DeprecatedValue(new_key="juju_homes_path"),
+        "openid-provider-url": DeprecatedValue(new_key="openid_provider_url"),
+        "openid-logout-url": DeprecatedValue(new_key="openid_logout_url"),
+        "oidc-client-id": DeprecatedValue(new_key="oidc_client_id"),
+        "oidc-client-secret": DeprecatedValue(new_key="oidc_client_secret"),
+        "oidc-issuer": DeprecatedValue(new_key="oidc_issuer"),
+        "oidc-provider": DeprecatedValue(new_key="oidc_provider"),
+        "oidc-redirect-uri": DeprecatedValue(new_key="oidc_redirect_uri"),
+        "repository-path": DeprecatedValue(new_key="repository_path"),
+        "reprepro-binary": DeprecatedValue(new_key="reprepro_binary"),
+        "sanitize-delay": DeprecatedValue(new_key="sanitize_delay"),
+        "secret-token": DeprecatedValue(new_key="secret_token"),
+        "ubuntu-images-path": DeprecatedValue(new_key="ubuntu_images_path"),
+        "ubuntu-one-redirect-url": DeprecatedValue(new_key="ubuntu_one_redirect_url"),
+    }
+    | DEPRECATED_SERVICE_OPTIONS,
+    "async_frontend": DEPRECATED_SERVICE_OPTIONS,
+    "fake_openid": {
+        "root-url": DeprecatedValue(new_key="root_url"),
+    }
+    | DEPRECATED_SERVICE_OPTIONS,
+    "features": {
+        "enable-employee-management": DeprecatedValue(new_key="employee_management"),
+        "enable-script-profiles": DeprecatedValue(new_key="script_profiles"),
+        "enable-self-service-account-creation": DeprecatedValue(
+            new_key="self_service_account_creation"
+        ),
+        "enable-self-service-payg": DeprecatedValue(new_key="self_service_payg"),
+        "enable-support-provider-login": DeprecatedValue(
+            new_key="support_provider_login"
+        ),
+        "enable-ubuntu-pro-licensing": DeprecatedValue(new_key="ubuntu_pro_licensing"),
+        "enable-usg-profiles": DeprecatedValue(new_key="usg_profiles"),
+        "enable-wsl-child-instance-profiles": DeprecatedValue(new_key="wsl_management"),
+    },
+    "hostagent_consumer": DEPRECATED_SERVICE_OPTIONS,
+    "hostagent_server": DEPRECATED_SERVICE_OPTIONS,
+    "job_handler": {
+        "accumulator-reconnection-delay": DeprecatedValue(
+            new_key="accumulator_reconnection_delay"
+        ),
+        "default-accumulator-delay": DeprecatedValue(
+            new_key="default_accumulator_delay"
+        ),
+    }
+    | DEPRECATED_SERVICE_OPTIONS,
+    "load_shaper": {
+        "critical-load": DeprecatedValue(new_key="critical_load"),
+        "good-duration": DeprecatedValue(new_key="good_duration"),
+        "good-load": DeprecatedValue(new_key="good_load"),
+    },
+    "maintenance": DEPRECATED_SERVICE_OPTIONS,
+    "message_server": {
+        "backoff-dirpath": DeprecatedValue(new_key="backoff_dirpath"),
+        "check-interval": DeprecatedValue(new_key="check_interval"),
+        "max-msg-size-bytes": DeprecatedValue(new_key="max_msg_size_bytes"),
+        "message-snippet-bytes": DeprecatedValue(new_key="message_snippet_bytes"),
+        "ping-interval": DeprecatedValue(new_key="ping_interval"),
+    }
+    | DEPRECATED_SERVICE_OPTIONS,
+    "oops": {
+        "amqp-exchange": DeprecatedValue(new_key="amqp_exchange"),
+        "amqp-key": DeprecatedValue(new_key="amqp_key"),
+    },
+    "package_search": {
+        "account-threshold": DeprecatedValue(new_key="account_threshold"),
+        "pid-path": DeprecatedValue(new_key="pid_path"),
+    }
+    | DEPRECATED_SERVICE_OPTIONS,
+    "package_upload": {
+        "root-url": DeprecatedValue(new_key="service_path"),
+    }
+    | DEPRECATED_SERVICE_OPTIONS,
+    "pingserver": {
+        "database-check-interval": DeprecatedValue(new_key="database_check_interval"),
+        "database-write-interval": DeprecatedValue(new_key="database_write_interval"),
+        "pingtracker-penalty-window-duration": DeprecatedValue(
+            new_key="pingtracker_penalty_window_duration"
+        ),
+        "pingtracker-window-duration": DeprecatedValue(
+            new_key="pingtracker_window_duration"
+        ),
+        "pingtracker-window-ping-limit": DeprecatedValue(
+            new_key="pingtracker_window_ping_limit"
+        ),
+    }
+    | DEPRECATED_SERVICE_OPTIONS,
+    "schema": DEPRECATED_SERVICE_OPTIONS,
+    "scripts": DEPRECATED_SERVICE_OPTIONS,
+    "secrets": {
+        "secrets-url": DeprecatedValue(new_key="vault_url"),
+        "secrets-service-url": DeprecatedValue(new_key="service_url"),
+    }
+    | DEPRECATED_SERVICE_OPTIONS,
+    "stores": {
+        "account-1": DeprecatedValue(new_key="account_1"),
+        "account-2": DeprecatedValue(new_key="account_2"),
+        "resource-1": DeprecatedValue(new_key="resource_1"),
+        "resource-2": DeprecatedValue(new_key="resource_2"),
+        "session-autocommit": DeprecatedValue(new_key="session_autocommit"),
+    },
+    "system": {
+        "audit-retention-period": DeprecatedValue(new_key="audit_retention_period"),
+        "deployment-mode": DeprecatedValue(new_key="deployment_mode"),
+        "max-service-memory": DeprecatedValue(new_key="max_service_memory"),
+        "oops-path": DeprecatedValue(new_key="oops_path"),
+        "pidfile-directory": DeprecatedValue(new_key="pidfile_directory"),
+        "root-url": DeprecatedValue(new_key="root_url"),
+        "syslog-address": DeprecatedValue(new_key="syslog_address"),
+    },
+    "ubuntu_installer_attach": DEPRECATED_SERVICE_OPTIONS,
+}
+
+
+def read_service_conf(service_conf=SERVICE_CONF) -> ConfigParser:
+    config = ConfigParser()
+    config.read(service_conf)
+    return config
+
+
+def migrate_service_conf(service_conf=SERVICE_CONF):
+    config = read_service_conf(service_conf)
+    new_config = defaultdict(dict)
+    for section in config.sections():
+        settings = config._sections[section]
+        if section in DEPRECATED_SECTIONS:
+            new_section = DEPRECATED_SECTIONS[section]
+            new_config[new_section] |= settings
+        elif section not in DELETED_SECTIONS:
+            new_config[section] |= settings
+    for new_section in DEPRECATED_SECTIONS.values():
+        if new_section not in new_config:
+            new_config[new_section] = {}
+    for section, deprecations in DEPRECATED_OPTIONS.items():
+        if section in new_config:
+            for deprecated_option, new_option in deprecations.items():
+                if deprecated_option in new_config[section]:
+                    value = new_config[section].pop(deprecated_option)
+                    if new_option.new_section is not None:
+                        new_section = new_option.new_section
+                    else:
+                        new_section = section
+                    new_config[new_section][new_option.new_key] = value
+    updated_config = ConfigParser()
+    updated_config.read_dict(new_config)
+    with open(service_conf, "w") as config_fp:
+        updated_config.write(config_fp)

--- a/tests/deprecated_service.conf
+++ b/tests/deprecated_service.conf
@@ -1,0 +1,194 @@
+[stores]
+user = landscape
+password = b64:bGFuZHNjYXBl
+# sslmode=verify-full
+# sslrootcert=/path/to/root-ca.crt
+# sslcert=/path/to/client.crt
+# sslkey=/path/to/client.key
+host = localhost
+main = landscape-test-main
+account-1 = landscape-test-account-1
+resource-1 = landscape-test-resource-1
+package = landscape-test-package
+session = landscape-test-session
+session-autocommit = landscape-test-session?isolation=autocommit
+knowledge = landscape-test-knowledge
+
+[global]
+# Syslog address is either a socket path or server:port string.
+syslog-address = /dev/log
+deployment-mode = default
+root-url = http://localhost:8080/
+pidfile-directory = /tmp/landscape
+
+[oops]
+path = /tmp/landscape-oops
+amqp-key = landscape-oops
+# Using an empty exchange makes the message go to a queue named after the key.
+# See https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default
+amqp-exchange = 
+
+[broker]
+port = 5672
+host = localhost
+user = landscape
+password = b64:bGFuZHNjYXBl
+vhost = landscape
+hostagent_virtual_host = landscape-hostagent
+hostagent_task_queue = landscape-server-hostagent-task-queue
+hostagent_ping_queue = landscape-server-hostagent-ping-queue
+
+[load-shaper]
+critical-load = 20.0
+good-load = 10.0
+good-duration = 60.0
+
+[landscape]
+base-port = 8080
+threads = 8
+stores = main account-1 resource-1 package session session-autocommit knowledge
+oops-key = DFA
+devmode = on
+mailer = default
+mailer-path = /tmp/landscape-mail-queue
+repository-path = /tmp/landscape-repository
+juju-homes-path = /var/tmp/juju-homes
+ubuntu-images-path = /var/tmp/ubuntu-images
+secret-token = 2d3dbbcb171b6c3e5446922f4ef85f5d080ff5429addb08037081bcdb6faae4aac482f1d2a970b88dd0f3083b64872efa338b699d9e6419010ca966718785ec4
+openid-provider-url = http://fake-openid.local/openid
+openid-logout-url = http://localhost:9500/openidlogout?success_to=http%%3A%%2F%%2Flocalhost%%3A8080%%2F&submit=true
+enable-subdomain-accounts = true
+enable-password-authentication = true
+# Only one auth provider should be used at a time.
+# If oidc is to be used, comment above openid- config and uncomment oidc-.
+#oidc-issuer = http://localhost:8080/oidc
+#oidc-client-id = develclient
+#oidc-client-secret = develsecret
+sanitize-delay = 3600
+blob-storage-root = /tmp/landscape/blobs/
+enable-saas-metrics = true
+#display-consent-banner-at-each-login = false
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[message-server]
+base-port = 8089
+threads = 2
+stores = main account-1 resource-1 package
+max-msg-size-bytes = 10000000
+message-snippet-bytes = 1000
+enable-metrics = true
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[pingserver]
+base-port = 8081
+stores = main account-1 resource-1
+threads = 2
+pingtracker-window-duration = 5
+pingtracker-window-ping-limit = 10
+pingtracker-penalty-window-duration = 120
+enable-metrics = true
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[job-handler]
+stores = main account-1 resource-1 package
+threads = 20
+mailer = queue
+mailer-path = /tmp/landscape-mail-queue
+
+[async-frontend]
+base-port = 19090
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[api]
+stores = main account-1 resource-1 package session
+threads = 10
+base-port = 9091
+root-url = http://localhost:9091
+mailer = queue
+mailer-path = /tmp/landscape-mail-queue
+devmode = on
+snap-store-api-url = https://api.snapcraft.io/v2
+cors-allow-all = 1
+enable-metrics = true
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[maintenance]
+threads = 1
+stores = main account-1 resource-1 package session session-autocommit knowledge
+mailer = queue
+mailer-path = /tmp/landscape-mail-queue
+
+[schema]
+threads = 1
+stores = main account-1 resource-1 package session knowledge
+store_user = landscape_superuser
+store_password = landscape
+# sslmode=verify-full
+# sslrootcert=/path/to/root-ca.crt
+# sslcert=/path/to/client.crt
+# sslkey=/path/to/client.key
+
+[scripts]
+threads = 1
+stores = main account-1 resource-1 package session knowledge
+mailer = queue
+mailer-path = /tmp/landscape-mail-queue
+
+[package-upload]
+stores = main account-1
+threads = 2
+port = 9090
+root-url = http://localhost:9090
+mailer = queue
+mailer-path = /tmp/landscape-mail-queue
+enable-metrics = true
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[package-search]
+port = 9099
+stores = main package resource-1
+account-threshold = 5
+pid-path = /tmp/package-search.pid
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[package_search]
+host = localhost
+
+[backoff]
+backoff-dirpath = ./configs
+
+[secrets]
+secrets-url = http://localhost:8200
+secrets-service-url = http://localhost:26155
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[hostagent-message-consumer]
+threads = 1
+stores = main account-1 resource-1
+
+[hostagent-message-server]
+threads = 1
+stores = main
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[ubuntu-installer-attach-message-server]
+threads = 1
+stores = main account-1
+#allowed_interfaces = localhost 127.0.0.1 ::1
+
+[fake-openid]
+# Changes here must be reflected in the dev HAProxy configuration, too.
+port = 9500
+root-url = http://fake-openid.local/
+
+[features]
+enable-employee-management = false
+enable-script-profiles = false
+enable-usg-profiles = false
+enable-support-provider-login = true
+enable-wsl-child-instance-profiles = false
+enable-self-service-payg = true
+enable-self-service-account-creation = true
+
+[pppa-proxy]
+supported-releases = 23.03 24.04

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1462,7 +1462,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._update_haproxy_connection.assert_called_once()
         mock_update_conf.assert_called_once_with(
             {
-                "package-search": {
+                "package_search": {
                     "host": "localhost",
                 },
             }
@@ -1490,7 +1490,7 @@ class TestCharm(unittest.TestCase):
         mock_update_conf.assert_called_once_with(
             
             {
-                    "package-search": {
+                    "package_search": {
                         "host": "test",
                     },
                 }

--- a/tests/test_settings_files.py
+++ b/tests/test_settings_files.py
@@ -2,16 +2,31 @@
 
 import os
 from base64 import b64encode
+from configparser import ConfigParser
 from io import BytesIO, StringIO
+import shutil
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 from urllib.error import URLError
 
+import charm
+import settings_files
 from settings_files import (
-    CONFIGS_DIR, LICENSE_FILE, LicenseFileReadException, SSLCertReadException,
-    configure_for_deployment_mode, merge_service_conf, prepend_default_settings,
-    update_default_settings, update_service_conf, write_license_file, write_ssl_cert)
+    CONFIGS_DIR,
+    configure_for_deployment_mode,
+    LICENSE_FILE,
+    LicenseFileReadException,
+    migrate_service_conf,
+    merge_service_conf,
+    prepend_default_settings,
+    read_service_conf,
+    SSLCertReadException,
+    update_default_settings,
+    update_service_conf,
+    write_license_file,
+    write_ssl_cert,
+)
 
 
 class CapturingBytesIO(BytesIO):
@@ -345,3 +360,41 @@ class WriteSSLCertTestCase(TestCase):
                 write_ssl_cert,
                 "notvalidb64haha",
             )
+
+class MigrateServiceConfTest(TestCase):
+
+    def test_migrate_service_conf(self):
+        tmpdir = TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+
+        deprecated_conf = os.path.join(tmpdir.name, "service.conf")
+        test_file = "tests/deprecated_service.conf"
+        shutil.copyfile(test_file, deprecated_conf)
+
+        expected_config = ConfigParser()
+        expected_config.read("tests/updated_service.conf")
+
+        migrate_service_conf(deprecated_conf)
+
+        config = read_service_conf(deprecated_conf)
+
+        self.assertEqual(expected_config, config)
+
+    def test_migrate_service_conf_idempotent(self):
+        tmpdir = TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+
+        deprecated_conf = os.path.join(tmpdir.name, "service.conf")
+        test_file = "tests/deprecated_service.conf"
+        shutil.copyfile(test_file, deprecated_conf)
+
+        expected_config = ConfigParser()
+        expected_config.read("tests/updated_service.conf")
+
+        migrate_service_conf(deprecated_conf)
+        first_pass = read_service_conf(deprecated_conf)
+
+        migrate_service_conf(deprecated_conf)
+        second_pass = read_service_conf(deprecated_conf)
+
+        self.assertEqual(first_pass, second_pass)

--- a/tests/updated_service.conf
+++ b/tests/updated_service.conf
@@ -1,0 +1,162 @@
+[stores]
+user = landscape
+password = b64:bGFuZHNjYXBl
+host = localhost
+main = landscape-test-main
+package = landscape-test-package
+session = landscape-test-session
+knowledge = landscape-test-knowledge
+account_1 = landscape-test-account-1
+resource_1 = landscape-test-resource-1
+session_autocommit = landscape-test-session?isolation=autocommit
+
+[system]
+enable_password_authentication = true
+enable_saas_metrics = true
+enable_subdomain_accounts = true
+deployment_mode = default
+pidfile_directory = /tmp/landscape
+root_url = http://localhost:8080/
+syslog_address = /dev/log
+
+[oops]
+path = /tmp/landscape-oops
+amqp_exchange = 
+amqp_key = landscape-oops
+
+[broker]
+port = 5672
+host = localhost
+user = landscape
+password = b64:bGFuZHNjYXBl
+vhost = landscape
+hostagent_virtual_host = landscape-hostagent
+hostagent_task_queue = landscape-server-hostagent-task-queue
+hostagent_ping_queue = landscape-server-hostagent-ping-queue
+
+[load_shaper]
+critical_load = 20.0
+good_duration = 60.0
+good_load = 10.0
+
+[appserver]
+threads = 8
+stores = main account-1 resource-1 package session session-autocommit knowledge
+devmode = on
+mailer = default
+blob_storage_root = /tmp/landscape/blobs/
+juju_homes_path = /var/tmp/juju-homes
+openid_provider_url = http://fake-openid.local/openid
+openid_logout_url = http://localhost:9500/openidlogout?success_to=http%%3A%%2F%%2Flocalhost%%3A8080%%2F&submit=true
+repository_path = /tmp/landscape-repository
+sanitize_delay = 3600
+secret_token = 2d3dbbcb171b6c3e5446922f4ef85f5d080ff5429addb08037081bcdb6faae4aac482f1d2a970b88dd0f3083b64872efa338b699d9e6419010ca966718785ec4
+ubuntu_images_path = /var/tmp/ubuntu-images
+base_port = 8080
+mailer_path = /tmp/landscape-mail-queue
+oops_key = DFA
+
+[message_server]
+threads = 2
+stores = main account-1 resource-1 package
+max_msg_size_bytes = 10000000
+message_snippet_bytes = 1000
+base_port = 8089
+enable_metrics = true
+
+[pingserver]
+stores = main account-1 resource-1
+threads = 2
+pingtracker_penalty_window_duration = 120
+pingtracker_window_duration = 5
+pingtracker_window_ping_limit = 10
+base_port = 8081
+enable_metrics = true
+
+[job_handler]
+stores = main account-1 resource-1 package
+threads = 20
+mailer = queue
+mailer_path = /tmp/landscape-mail-queue
+
+[async_frontend]
+base_port = 19090
+
+[api]
+stores = main account-1 resource-1 package session
+threads = 10
+mailer = queue
+devmode = on
+cors_allow_all = 1
+root_url = http://localhost:9091
+snap_store_api_url = https://api.snapcraft.io/v2
+base_port = 9091
+enable_metrics = true
+mailer_path = /tmp/landscape-mail-queue
+
+[maintenance]
+threads = 1
+stores = main account-1 resource-1 package session session-autocommit knowledge
+mailer = queue
+mailer_path = /tmp/landscape-mail-queue
+
+[schema]
+threads = 1
+stores = main account-1 resource-1 package session knowledge
+store_user = landscape_superuser
+store_password = landscape
+
+[scripts]
+threads = 1
+stores = main account-1 resource-1 package session knowledge
+mailer = queue
+mailer_path = /tmp/landscape-mail-queue
+
+[package_upload]
+stores = main account-1
+threads = 2
+port = 9090
+mailer = queue
+service_path = http://localhost:9090
+enable_metrics = true
+mailer_path = /tmp/landscape-mail-queue
+
+[package_search]
+port = 9099
+stores = main package resource-1
+account_threshold = 5
+pid_path = /tmp/package-search.pid
+host = localhost
+
+[backoff]
+backoff-dirpath = ./configs
+
+[secrets]
+vault_url = http://localhost:8200
+service_url = http://localhost:26155
+
+[hostagent_consumer]
+threads = 1
+stores = main account-1 resource-1
+
+[hostagent_server]
+threads = 1
+stores = main
+
+[ubuntu_installer_attach]
+threads = 1
+stores = main account-1
+
+[fake_openid]
+port = 9500
+root_url = http://fake-openid.local/
+
+[features]
+employee_management = false
+script_profiles = false
+self_service_account_creation = true
+self_service_payg = true
+support_provider_login = true
+usg_profiles = false
+wsl_management = false
+


### PR DESCRIPTION
# Manual Testing

Deploy the bundle.

`make build`

Check the `package-search` and `package_search` sections of the `service.conf` file.

`juju exec --app landscape-server -- sudo cat /etc/landscape/service.conf | grep -A 5 'package_search'`

`juju exec --app landscape-server -- sudo cat /etc/landscape/service.conf | grep -A 5 'package-search'`

Apply the action.

`juju run landscape-server/0 migrate-service-conf`

Check the sections again.

`juju exec --app landscape-server -- sudo cat /etc/landscape/service.conf | grep -A 5 'package_search'`

`juju exec --app landscape-server -- sudo cat /etc/landscape/service.conf | grep -A 5 'package-search'`

Add two new units. Migrate their service.conf files, too.

`juju add-unit -n 2 landscape-server`

`juju run landscape-server/1 migrate-service-conf`

`juju run landscape-server/2 migrate-service-conf`

Wait for them to stabilize. Then remove the leader unit to trigger a leadership change.

`juju remove-unit landscape-server/0`

Check the `package_search` section was updated correctly for the new leader.

`juju exec --app landscape-server -- sudo cat /etc/landscape/service.conf | grep -A 5 'package_search'`

`note`: The beta install is probably broken at the moment. We'll fix it soon.
