### PR TITLE
feat: migrate service conf when possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 venv
 __pycache__
 *.charm
+.tox

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,6 +1,21 @@
-# Copyright 2022 Canonical Ltd
+# Copyright 2025 Canonical Ltd
 # See LICENSE file for licensing details.
 
+hash-id-databases:
+  description: |
+    Regenerate the package hash to id mapping files that are used to
+    speed up client package reporting.
+migrate-schema:
+  description: |
+    Upgrade the Landscape database schemas on the related databases.
+    Unit must already be paused using the 'pause' action.
+migrate-service-conf:
+  description: |
+    Migrate the service.conf file to have the sections and settings that
+    are expected by the Pydantic Settings models.
+
+    This action is idempotent. It has no effect if the Landscape Server package
+    did not ship with the corresponding script.
 pause:
   description: Pause the Landscape services.
 resume:
@@ -10,11 +25,3 @@ upgrade:
     Upgrade software on the Landscape Server unit. This will update
     APT package indices and upgrade the landscape-server package. Unit must
     already be paused using the 'pause' action.
-migrate-schema:
-  description: |
-    Upgrade the Landscape database schemas on the related databases.
-    Unit must already be paused using the 'pause' action.
-hash-id-databases:
-  description: |
-    Regenerate the package hash to id mapping files that are used to
-    speed up client package reporting.

--- a/bundle-examples/bundle.yaml
+++ b/bundle-examples/bundle.yaml
@@ -31,8 +31,11 @@ applications:
     charm: ../landscape-server_ubuntu@22.04-amd64.charm
     num_units: 1
     options:
-        landscape_ppa: ppa:landscape/self-hosted-beta
+        landscape_ppa: ppa:landscape/latest-stable
         min_install: True
+        additional_service_config: |
+          [api]
+          cookie-encryption-key = Lhc4EWVuIHjsUYy-jk1v6LjQ46O2vwB94KkpOtld6jA=
 relations:
   - [landscape-server:inbound-amqp, rabbitmq-server]
   - [landscape-server:outbound-amqp, rabbitmq-server]

--- a/copyright
+++ b/copyright
@@ -1,7 +1,7 @@
 Format: http://dep.debian.net/deps/dep5/
 
 Files: *
-Copyright: Copyright 2022, Canonical Ltd., All Rights Reserved.
+Copyright: Copyright 2025, Canonical Ltd., All Rights Reserved.
 License: GPL-2
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/lib/charms/grafana_agent/LICENSE
+++ b/lib/charms/grafana_agent/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 Canonical Ltd.
+   Copyright 2025 Canonical Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 r"""## Overview.

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/charms/operator_libs_linux/v0/passwd.py
+++ b/lib/charms/operator_libs_linux/v0/passwd.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd
+# Copyright 2025 Canonical Ltd
 # See LICENSE file for licensing details.
 
 # For a complete list of supported options, see:

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,0 +1,39 @@
+import logging
+import os
+import subprocess
+import sys
+
+logger = logging.getLogger("landscape-charm")
+
+MIGRATE_SERVICE_CONF_SCRIPT = "/opt/canonical/landscape/migrate-service-conf"
+
+
+def get_modified_env_vars():
+    """
+    Because the python path gets munged by the juju env, this grabs the current
+    env vars and returns a copy with the juju env removed from the python paths
+    """
+    env_vars = os.environ.copy()
+    logger.info("Fixing python paths")
+    new_paths = [path for path in sys.path if "juju" not in path]
+    env_vars["PYTHONPATH"] = ":".join(new_paths) + ":/opt/canonical/landscape"
+    return env_vars
+
+
+def migrate_service_conf() -> None:
+    if os.path.isfile(MIGRATE_SERVICE_CONF_SCRIPT):
+        try:
+            migrate_result = subprocess.run(
+                [MIGRATE_SERVICE_CONF_SCRIPT],
+                capture_output=True,
+                text=True,
+                check=True,
+                env=get_modified_env_vars(),
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(
+                "Migrating service.conf failed with return code %s", e.returncode
+            )
+            logger.error("Failed to migrate service.conf: %s", migrate_result)
+        else:
+            logger.info("Migrated service.conf: %s", migrate_result)

--- a/src/settings_files.py
+++ b/src/settings_files.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd
+# Copyright 2025 Canonical Ltd
 
 """
 Functions for manipulating Landscape Server service settings in the
@@ -13,6 +13,8 @@ import secrets
 from string import ascii_letters, digits
 from urllib.error import URLError
 from urllib.request import urlopen
+
+from helpers import migrate_service_conf
 
 CONFIGS_DIR = "/opt/canonical/landscape/configs"
 
@@ -144,6 +146,8 @@ def update_service_conf(updates: dict) -> None:
 
     with open(SERVICE_CONF, "w") as config_fp:
         config.write(config_fp)
+
+    migrate_service_conf()
 
 
 def generate_secret_token():

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1,7 +1,8 @@
-# Copyright 2022 Canonical Ltd
+# Copyright 2025 Canonical Ltd
 # See LICENSE file for licensing details.
 #
-# Learn more about testing at: https://juju.is/docs/sdk/testing
+# Learn more about testing at
+# https://documentation.ubuntu.com/ops/latest/explanation/testing/
 
 from base64 import b64encode
 from dataclasses import asdict

--- a/tests/test_settings_files.py
+++ b/tests/test_settings_files.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd
+# Copyright 2025 Canonical Ltd
 
 import os
 from base64 import b64encode
@@ -210,9 +210,13 @@ class UpdateServiceConfTestCase(TestCase):
             i += 1
             return retval
 
-        with patch("os.path.isfile") as mock_isfile:
-            with patch("builtins.open") as open_mock:
+        with (
+            patch("os.path.isfile") as mock_isfile,
+            patch("builtins.open") as open_mock,
+            patch("settings_files.migrate_service_conf") as mock_migrate_service_conf
+        ):
                 mock_isfile.return_value = True
+                mock_migrate_service_conf.return_value = None
                 open_mock.side_effect = return_conf
                 update_service_conf({"test": {"new": "yes"}})
 
@@ -232,9 +236,13 @@ class UpdateServiceConfTestCase(TestCase):
             i += 1
             return retval
 
-        with patch("os.path.isfile") as mock_isfile:
-            with patch("builtins.open") as open_mock:
+        with (
+            patch("os.path.isfile") as mock_isfile,
+            patch("builtins.open") as open_mock,
+            patch("settings_files.migrate_service_conf") as mock_migrate_service_conf
+        ):
                 mock_isfile.return_value = True
+                mock_migrate_service_conf.return_value = None
                 open_mock.side_effect = return_conf
                 update_service_conf({"fixed": {"old": "yes"}})
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,3 +40,6 @@ commands =
 filterwarnings =
     # TODO migrate off of Harness.
     once:.*Harness is deprecated.*:PendingDeprecationWarning
+
+[tox]
+skipsdist = true


### PR DESCRIPTION
NOTE: This PR contains a commit that modifies the example `bundle.yaml` file. Those changes are to aid in manual testing and will be reverted before the PR is merged.

# Manual Testing Instructions

1. Deploy the bundle, wait for it to stabilize, and create the first admin. Optionally, do something "Landscape-y" like registering a computer.

    ```bash
    make build
    ```

1. Review the last modified date of the `service.conf` file that gets installed.

    ```bash
    juju exec --app landscape-server -- sudo ls -la /etc/landscape/service.conf
    ```

1. Test the new action. There should be no output.

    ```bash
    juju run landscape-server/0 migrate-service-conf
    ```

1. Check the file was not modified.

    ```bash
    juju exec --app landscape-server -- sudo ls -la /etc/landscape/service.conf
    ```

1. Pause the services.

    ```bash
    juju run landscape-server/0 pause
    ```

1. Add the beta PPA.

    ```bash
    juju exec --app landscape-server -- sudo add-apt-repository -y ppa:landscape/self-hosted-beta
    ```

1. Upgrade Landscape Server

    ```bash
    juju run landscape-server/0 upgrade
    ```

1. Perform a database schema migration.

    ```bash
    juju run landscape-server/0 migrate-schema
    ```

1. Resume the services.

    ```bash
    juju run landscape-server/0 resume
    ```

1. Check the contents of the `etc` directory. There should be a backup of the previous `service.conf` file.

    ```bash
    juju exec --app landscape-server -- ls /etc/landscape/
    ```

1. Test the new action again. There should be no output.

    ```bash
    juju run landscape-server/0 migrate-service-conf
    ```

1. Check the contents of the `etc` directory. There should be another backup of the `service.conf` file.

    ```bash
    juju exec --app landscape-server -- ls /etc/landscape/
    ```

1. Try to break something.
