### PR TITLE
fix: Add simple config option to make ping service use HTTPS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -209,3 +209,9 @@ options:
     description: |
       Bypassed Landscape administrator registration approval for clients that
       register using the registration password.
+  ping_https:
+    type: boolean
+    default: false
+    description: |
+      If true, /ping endpoint will redirect and serve over HTTPS only. 
+      If false, /ping endpoint will be available and served over both HTTP and HTTPS.

--- a/src/charm.py
+++ b/src/charm.py
@@ -227,6 +227,12 @@ def _create_haproxy_services(
     ]
 
     http_service["servers"] = appservers
+    http_service["backends"] = [
+        {
+            "backend_name": "landscape-ping",
+            "servers": pingservers,
+        }
+    ]
     https_service["servers"] = appservers
     https_service["backends"] = [
         {

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1762,7 +1762,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
         backend_stanza = {"backend_name": "landscape-ping", "servers": ANY}
 
         self.assertIn(backend_stanza, http["backends"])
-        self.assertIn(backend_stanza, https["backends"])
+        self.assertNotIn(backend_stanza, https["backends"])
 
     def test_https_services(self):
         """
@@ -1793,6 +1793,30 @@ class TestCreateHAProxyServices(unittest.TestCase):
         for backend_stanza in backend_stanzas:
             self.assertNotIn(backend_stanza, http["backends"])
             self.assertIn(backend_stanza, https["backends"])
+
+    def test_ping_http_services(self):
+        """
+        pingserver is served over HTTPs.
+        """
+        http, https, grpc = _create_haproxy_services(
+            http_service=self.http_service,
+            https_service=self.https_service,
+            grpc_service=self.grpc_service,
+            ssl_cert="",
+            server_ip="",
+            unit_name="",
+            worker_counts=1,
+            is_leader=False,
+            error_files=(),
+            service_ports=self.service_ports,
+            server_options=self.server_options,
+            ping_https=False,
+        )
+
+        backend_stanza = {"backend_name": "landscape-ping", "servers": ANY}
+
+        self.assertIn(backend_stanza, http["backends"])
+        self.assertNotIn(backend_stanza, https["backends"])
 
     def test_ping_https_services(self):
         """
@@ -1939,7 +1963,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
         }
 
         self.assertIn(expected, http["backends"])
-        self.assertIn(expected, https["backends"])
+        self.assertNotIn(expected, https["backends"])
 
     def test_configure_message_servers(self):
         """

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1540,6 +1540,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         self.assertIn(ssl_cert, https["crts"])
@@ -1574,6 +1575,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=error_files,
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         for service in (http, https, grpc):
@@ -1581,7 +1583,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
 
     def test_http_services(self):
         """
-        pingserver and appserver are served over HTTP.
+        pingserver is served over both HTTP and HTTPs.
         """
         http, https, grpc = _create_haproxy_services(
             http_service=self.http_service,
@@ -1595,11 +1597,12 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
         backend_stanza = {"backend_name": "landscape-ping", "servers": ANY}
 
         self.assertIn(backend_stanza, http["backends"])
-        self.assertNotIn(backend_stanza, https["backends"])
+        self.assertIn(backend_stanza, https["backends"])
 
     def test_https_services(self):
         """
@@ -1617,6 +1620,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         backend_stanzas = (
@@ -1629,6 +1633,30 @@ class TestCreateHAProxyServices(unittest.TestCase):
         for backend_stanza in backend_stanzas:
             self.assertNotIn(backend_stanza, http["backends"])
             self.assertIn(backend_stanza, https["backends"])
+
+    def test_ping_https_services(self):
+        """
+        pingserver is served over HTTPs.
+        """
+        http, https, grpc = _create_haproxy_services(
+            http_service=self.http_service,
+            https_service=self.https_service,
+            grpc_service=self.grpc_service,
+            ssl_cert="",
+            server_ip="",
+            unit_name="",
+            worker_counts=1,
+            is_leader=False,
+            error_files=(),
+            service_ports=self.service_ports,
+            server_options=self.server_options,
+            ping_https=True,
+        )
+
+        backend_stanza = {"backend_name": "landscape-ping", "servers": ANY}
+
+        self.assertNotIn(backend_stanza, http["backends"])
+        self.assertIn(backend_stanza, https["backends"])
 
     def test_configure_grpc_services(self):
         """
@@ -1656,6 +1684,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         expected = [
@@ -1695,6 +1724,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         expected = [
@@ -1732,6 +1762,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         expected = {
@@ -1748,7 +1779,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
         }
 
         self.assertIn(expected, http["backends"])
-        self.assertNotIn(expected, https["backends"])
+        self.assertIn(expected, https["backends"])
 
     def test_configure_message_servers(self):
         """
@@ -1773,6 +1804,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         expected = {
@@ -1814,6 +1846,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         expected = {
@@ -1858,6 +1891,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         expected = {
@@ -1887,6 +1921,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         expected = {
@@ -1920,6 +1955,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         expected = {
@@ -1950,6 +1986,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
+            ping_https=False,
         )
 
         expected = {"backend_name": "landscape-hashid-databases", "servers": []}


### PR DESCRIPTION
## Context
https://warthogs.atlassian.net/browse/LNDENG-2808

## Doc Changes
https://github.com/canonical/landscape-documentation/pull/81

## Manual Testing
```bash
# 1. Bootstrap Juju
juju bootstrap
## Select a cloud [localhost]
## Enter a name for the Controller [localhost-localhost]

# 2. Add model
juju add-model landscape-charm-build

# 3. Build local charm
make build

# 4. Watch units (ensure no errors)
juju status --watch 3s

# Note: If the haproxy App/Unit does not become "active", you might have to manually connect the endpoints with 
juju integrate landscape-server:website haproxy:reverseproxy

# 5. Expose landscape-server
juju expose landscape-server

# 6. Verify that ping_https is set to false
juju config landscape-server ping_https

# 7. Ping server
curl http://<Haproxy-ip>/ping -i -k

# 8. Enable HTTPS
juju config landscape-server ping_https=true

# 9. Verify that ping_https is set to true
juju config landscape-server ping_https

# 10. Ensure that https works over the Haproxy ip:
curl https://<Haproxy-ip>/ping -i -k


```