### PR TITLE
fix: KeyError during `_on_config_changed` that prevents deployment

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -588,8 +588,6 @@ class LandscapeServerCharm(CharmBase):
         a replica.
 
         If set on neither, return `None`.
-
-        FIXME raises an exception if not set locally and there is no replica.
         """
         secret_token = self.model.config.get("secret_token")
         if not secret_token:

--- a/src/charm.py
+++ b/src/charm.py
@@ -584,8 +584,8 @@ class LandscapeServerCharm(CharmBase):
 
     def _get_secret_token(self) -> str | None:
         """
-        Get the JWT secret token from either the juju config for this unit, or from
-        a replica.
+        Get the `secret-token` config from either the juju config for this unit, or from
+        app data in the replica relation.
 
         If set on neither, return `None`.
         """


### PR DESCRIPTION
## Context

We can't deploy a fresh `landscape-server` charm due to a KeyError. This PR fixes that, and also cleans up an edge case where there is no replica relation and we haven't provided a `secret-token`.

This also expands our use of the newer `Context`-based unit tests for charms. See https://documentation.ubuntu.com/ops/latest/howto/write-unit-tests-for-a-charm/# for more details. I rely on `pytest` to create a fixture that more easily lets us inspect the state of the Landscape configuration.

This means our tests will need to continue running under `pytest`. We already do this with `tox`, so it isn't a deviation from current behavior. But it is a commitment that we'd need to honor moving forward.

## Manual testing

Build from `main` and deploy. See that we can modify the root URL successfully:

```sh
juju config landscape-server root_url = <some root url>
```

The "config changed" hook should succeed.