### PR TITLE
feat: add HAProxy frontend for ubuntu installer attach service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -182,6 +182,7 @@ def _create_haproxy_services(
     http_service: dict,
     https_service: dict,
     grpc_service: dict,
+    ubuntu_installer_attach_service: dict,
     ssl_cert: bytes | str,
     server_ip: str,
     unit_name: str,
@@ -267,14 +268,25 @@ def _create_haproxy_services(
         )
         for i in range(worker_counts)
     ]
-
     grpc_service["servers"] = hostagent_messengers
+
+    ubuntu_installer_attach_server = [
+        (
+            f"landscape-ubuntu-installer-attach-{unit_name}-0",
+            server_ip,
+            service_ports["ubuntu-installer-attach"],
+            server_options + ubuntu_installer_attach_service["server_options"],
+        )
+    ]
+
+    ubuntu_installer_attach_service["servers"] = ubuntu_installer_attach_server
 
     http_service["error_files"] = [asdict(ef) for ef in error_files]
     https_service["error_files"] = [asdict(ef) for ef in error_files]
     grpc_service["error_files"] = [asdict(ef) for ef in error_files]
+    ubuntu_installer_attach_service["error_files"] = [asdict(ef) for ef in error_files]
 
-    return http_service, https_service, grpc_service
+    return http_service, https_service, grpc_service, ubuntu_installer_attach_service
 
 
 @dataclass
@@ -316,6 +328,7 @@ Expects the following keys:
 - api
 - package-upload
 - hostagent-messenger
+- ubuntu-installer-attach
 
 Each value is the port that service runs on.
 """
@@ -333,14 +346,6 @@ Additional configuration for a `server` stanza in an HAProxy configuration.
 
 def _get_haproxy_server_options(haproxy_config: dict) -> HAProxyServerOptions:
     return haproxy_config["server_options"]
-
-
-def _get_haproxy_services(haproxy_config: dict) -> tuple[dict, dict, dict]:
-    http_service = haproxy_config["http_service"]
-    https_service = haproxy_config["https_service"]
-    grpc_service = haproxy_config["grpc_service"]
-
-    return (http_service, https_service, grpc_service)
 
 
 class SSLConfigurationError(Exception):
@@ -992,25 +997,39 @@ class LandscapeServerCharm(CharmBase):
         error_files = _get_haproxy_error_files(haproxy_config)
         service_ports = _get_haproxy_service_ports(haproxy_config)
         server_options = _get_haproxy_server_options(haproxy_config)
-        http, https, grpc = _get_haproxy_services(haproxy_config)
 
-        http_service, https_service, grpc_service = _create_haproxy_services(
-            http_service=http,
-            https_service=https,
-            grpc_service=grpc,
-            ssl_cert=ssl_cert,
-            server_ip=relation.data[self.unit]["private-address"],
-            unit_name=self.unit.name.replace("/", "-"),
-            worker_counts=int(self.model.config["worker_counts"]),
-            is_leader=self.unit.is_leader(),
-            error_files=error_files,
-            service_ports=service_ports,
-            server_options=server_options,
+        http = haproxy_config["http_service"]
+        https = haproxy_config["https_service"]
+        grpc = haproxy_config["grpc_service"]
+        ubuntu_installer_attach = haproxy_config["ubuntu_installer_attach_service"]
+
+        http_service, https_service, grpc_service, ubuntu_installer_attach_service = (
+            _create_haproxy_services(
+                http_service=http,
+                https_service=https,
+                grpc_service=grpc,
+                ubuntu_installer_attach_service=ubuntu_installer_attach,
+                ssl_cert=ssl_cert,
+                server_ip=relation.data[self.unit]["private-address"],
+                unit_name=self.unit.name.replace("/", "-"),
+                worker_counts=int(self.model.config["worker_counts"]),
+                is_leader=self.unit.is_leader(),
+                error_files=error_files,
+                service_ports=service_ports,
+                server_options=server_options,
+            )
         )
 
         relation.data[self.unit].update(
             {
-                "services": yaml.safe_dump([http_service, https_service, grpc_service]),
+                "services": yaml.safe_dump(
+                    [
+                        http_service,
+                        https_service,
+                        grpc_service,
+                        ubuntu_installer_attach_service,
+                    ]
+                ),
             }
         )
 

--- a/src/haproxy-config.yaml
+++ b/src/haproxy-config.yaml
@@ -76,6 +76,13 @@ grpc_service:
   server_options: 
     - proto h2
 
+ubuntu_installer_attach_service:
+  service_name: landscape-ubuntu-installer-attach
+  service_host: 0.0.0.0
+  service_port: 50051
+  server_options: 
+    - proto h2
+
 error_files:
   location: /opt/canonical/landscape/canonical/landscape/offline
   files:
@@ -92,6 +99,7 @@ ports:
   api: 9080
   package-upload: 9100
   hostagent-messenger: 50052
+  ubuntu-installer-attach: 53354
 
 server_options:
   - check


### PR DESCRIPTION
## Context

We need an HAProxy frontend to route this traffic properly on Juju.

## Manual testing

```sh
charmcraft pack
juju add-model ubuntu-installer-test
juju deploy ./bundle-examples/bundle.yaml
```

Try hitting the gRPC service using either a mocker like Kreya or a real Ubuntu installer client. If you can request an attach code, then this is a successful test.