### PR TITLE
fix: use cert for ubuntu installer frontend

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -203,6 +203,7 @@ def _create_haproxy_services(
 
     https_service["crts"] = [ssl_cert]
     grpc_service["crts"] = [ssl_cert]
+    ubuntu_installer_attach_service["crts"] = [ssl_cert]
 
     (appservers, pingservers, message_servers, api_servers) = [
         [

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1931,17 +1931,21 @@ class TestCreateHAProxyServices(unittest.TestCase):
 
         It receives a `landscape-ubuntu-installer-attach-<unit name>-0 name,
         the server_ip, the correct port, and the server options.
+
+        The Ubuntu installer attach service uses an SSL frontend and uses the
+        provided cert.
         """
 
         server_ip = "10.194.61.5"
         unit_name = "0"
+        cert = "some ssl data"
 
         http, https, grpc, ubuntu_installer_attach = _create_haproxy_services(
             http_service=self.http_service,
             https_service=self.https_service,
             grpc_service=self.grpc_service,
             ubuntu_installer_attach_service=self.ubuntu_installer_attach_service,
-            ssl_cert="",
+            ssl_cert=cert,
             server_ip=server_ip,
             unit_name=unit_name,
             worker_counts=1,
@@ -1964,6 +1968,7 @@ class TestCreateHAProxyServices(unittest.TestCase):
         ]
 
         self.assertEqual(expected, ubuntu_installer_attach["servers"])
+        self.assertEqual([cert], ubuntu_installer_attach["crts"])
 
     def test_configure_appservers(self):
         """


### PR DESCRIPTION
## Context

We need to use TLS when delivering autoinstall files since they can have sensitive data. This changes the HTTP/2 frontend for the Ubuntu installer attach service to use TLS.

## Manual testing

It's sufficient to deploy this and ensure the HAProxy configuration includes TLS:

```
charmcraft pack
juju deploy 
juju deploy ./bundle-examples/bundle.yaml
```

Then check that the frontend uses a cert:

```sh
juju exec --unit haproxy/0 -- cat /etc/haproxy/haproxy.cfg
```

```
frontend haproxy-0-50051
    bind 0.0.0.0:50051 ssl crt /var/lib/haproxy/default.pem no-sslv3
    default_backend landscape-ubuntu-installer-attach
    acl host_found hdr(host) -m found
    http-request set-var(req.full_fqdn) hdr(authority) if !host_found
    http-request set-var(req.full_fqdn) hdr(host) if host_found
    http-request set-header X-FQDN %[var(req.full_fqdn)]
```

## Extra credit

You can use a gRPC mocker like Kreya to hit the `Attach` service. If we get an "untrusted certificate" error, that is a passing test.