### PR TITLE
fix: do not use `worker_count` for the hostagent-messenger service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -305,7 +305,6 @@ def _create_grpc_service(
     ssl_cert: bytes | str,
     server_ip: str,
     unit_name: str,
-    worker_counts: int,
     error_files: Iterable["HAProxyErrorFile"],
     service_ports: "HAProxyServicePorts",
     server_options: "HAProxyServerOptions",
@@ -315,16 +314,15 @@ def _create_grpc_service(
     """
 
     grpc_service["crts"] = [ssl_cert]
-    hostagent_messengers = [
+    hostagent_messenger = [
         (
-            f"landscape-hostagent-messenger-{unit_name}-{i}",
+            f"landscape-hostagent-messenger-{unit_name}-0",
             server_ip,
-            service_ports["hostagent-messenger"] + i,
+            service_ports["hostagent-messenger"],
             server_options + grpc_service["server_options"],
         )
-        for i in range(worker_counts)
     ]
-    grpc_service["servers"] = hostagent_messengers
+    grpc_service["servers"] = hostagent_messenger
     grpc_service["error_files"] = [asdict(ef) for ef in error_files]
 
     return grpc_service
@@ -1129,7 +1127,6 @@ class LandscapeServerCharm(CharmBase):
             ssl_cert=ssl_cert,
             server_ip=server_ip,
             unit_name=unit_name,
-            worker_counts=worker_counts,
             error_files=error_files,
             service_ports=service_ports,
             server_options=server_options,

--- a/tests/test_haproxy_relation.py
+++ b/tests/test_haproxy_relation.py
@@ -791,7 +791,6 @@ class TestCreateGRPCService(unittest.TestCase):
             ssl_cert=ssl_cert,
             server_ip="",
             unit_name="",
-            worker_counts=1,
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
@@ -814,7 +813,6 @@ class TestCreateGRPCService(unittest.TestCase):
             ssl_cert="",
             server_ip=server_ip,
             unit_name=unitname,
-            worker_counts=1,
             error_files=(),
             service_ports=self.service_ports,
             server_options=self.server_options,
@@ -828,39 +826,6 @@ class TestCreateGRPCService(unittest.TestCase):
                 self.hostagent_port,
                 options,
             )
-        ]
-
-        self.assertEqual(expected, service["servers"])
-
-    def test_hostagent_messenger_workers(self):
-        """
-        Creates a landscape-hostagent-messenger backend for each worker, incrementing
-        the port by 1.
-        """
-        workers = 3
-        server_ip = "10.194.61.5"
-        unitname = "unitname"
-
-        service = _create_grpc_service(
-            grpc_service=self.grpc_service,
-            ssl_cert="",
-            server_ip=server_ip,
-            unit_name=unitname,
-            worker_counts=workers,
-            error_files=(),
-            service_ports=self.service_ports,
-            server_options=self.server_options,
-        )
-
-        options = self.server_options + self.grpc_service["server_options"]
-        expected = [
-            (
-                f"landscape-hostagent-messenger-{unitname}-{i}",
-                server_ip,
-                self.hostagent_port + i,
-                options,
-            )
-            for i in range(workers)
         ]
 
         self.assertEqual(expected, service["servers"])
@@ -880,7 +845,6 @@ class TestCreateGRPCService(unittest.TestCase):
             ssl_cert="",
             server_ip="",
             unit_name="",
-            worker_counts=1,
             error_files=error_files,
             service_ports=self.service_ports,
             server_options=self.server_options,


### PR DESCRIPTION
## Context

The `worker_counts` configuration will create multiple HAProxy servers for a frontend. This configuration gets passed along to Landscape to spawn the correct number of services.

If there are additional servers created on a frontend but no actual services running to service them, then HAProxy will fail health checks and produce alerts through NRPE, for example.

## Manual testing

You can repro this problem in `main`:

```sh
charmcraft pack
juju add-model mainscape 
juju deploy ./bundle-examples/bundle.yaml
juju config landscape-server worker_counts=2
juju exec --unit haproxy/0 -- cat /etc/haproxy/haproxy.cfg
```

```
backend landscape-grpc
    server landscape-hostagent-messenger-landscape-server-0-0 10.194.61.180:50052 check inter 5000 rise 2 fall 5 maxconn 50 proto h2
    server landscape-hostagent-messenger-landscape-server-0-1 10.194.61.180:50053 check inter 5000 rise 2 fall 5 maxconn 50 proto h2
```

Notice that there are multiple servers for the `landscape-grpc` frontend. SSH into the Landscape server unit and notice that there are not actually enough `hostagent-messenger` services to fulfill this:

```sh
juju ssh landscape-server/0
ps aux | grep landscape-hostagent
```

Compare this with the `pingserver` or `api`, which have multiple workers.

Then, check out this branch and refresh:

```sh
charmcraft pack
juju refresh landscape-server --path ./landscape-server_ubuntu@22.04-amd64.charm
juju exec --unit haproxy/0 -- cat /etc/haproxy/haproxy.cfg
```

```sh
juju exec --unit haproxy/0 -- cat /etc/haproxy/haproxy.cfg
```

```
backend landscape-grpc
    server landscape-hostagent-messenger-landscape-server-0-0 10.194.61.180:50052 check inter 5000 rise 2 fall 5 maxconn 50 proto h2
```